### PR TITLE
DiabloImmortal_Mesh.bt: Additional Buffer descriptors

### DIFF
--- a/DiabloImmortal_Mesh.bt
+++ b/DiabloImmortal_Mesh.bt
@@ -80,6 +80,73 @@ struct VERTEX_BUFFER(char description[], int size)
         VECTOR4H tangentAsQuat;
         VECTOR2H uv;
     }
+    else if( bufferMatch( "P3F_C4B_N4B_T2F", description, 15, size ) )
+    {
+        VECTOR3 position;
+        RGBA32 color;
+        VECTOR4SMALL normal;                                 // Packed normal 
+        VECTOR2 uv;
+    }
+    else if( bufferMatch( "Q4H_T2H_T2H", description, 11, size ) )
+    {
+        VECTOR4H tangentAsQuat;
+        VECTOR2H uv;
+        VECTOR2H texture2;
+    }
+    else if( bufferMatch( "Q4H_T2H_T4H", description, 11, size ) )
+    {
+        VECTOR4H tangentAsQuat;
+        VECTOR2H uv;
+        VECTOR4H texture4;
+    }
+    else if( bufferMatch( "C4B_Q4H_T2H_T2H", description, 15, size ) )
+    {
+        RGBA32 color;
+        VECTOR4H tangentAsQuat;
+        VECTOR2H uv;
+        VECTOR2H texture2;
+    }
+    else if( bufferMatch( "C4B_Q4H_T2H_T4H", description, 15, size ) )
+    {
+        RGBA32 color;
+        VECTOR4H tangentAsQuat;
+        VECTOR2H uv;
+        VECTOR4H texture4;
+    }
+    else if( bufferMatch( "C4B_Q4H_T2H_T2H_T4H", description, 19, size ) )
+    {
+        RGBA32 color;
+        VECTOR4H tangentAsQuat;
+        VECTOR2H uv;
+        VECTOR2H texture2;
+        VECTOR4H texture4;
+    }
+    else if( bufferMatch( "C4B_N4B_T2H_T2H", description, 15, size ) )
+    {
+        RGBA32 color;
+        VECTOR4SMALL normal;                                 // Packed normal 
+        VECTOR2H uv;
+        VECTOR2H texture2;
+    }
+    else if( bufferMatch( "Q4H_T2H_T2H_T4H", description, 15, size ) )
+    {
+        VECTOR4H tangentAsQuat;
+        VECTOR2H uv;
+        VECTOR2H texture2;
+        VECTOR4H texture4;
+    }
+    else if( bufferMatch( "N4B_T2H_T2H", description, 11, size ) )
+    {
+        VECTOR4SMALL normal;                                 // Packed normal 
+        VECTOR2H uv;
+        VECTOR2H texture2;
+    }
+    else if( bufferMatch( "N4B_T2H_T4H", description, 11, size ) )
+    {
+        VECTOR4SMALL normal;                                 // Packed normal 
+        VECTOR2H uv;
+        VECTOR4H texture4;
+    }
     else
     {
         // Idk


### PR DESCRIPTION
I've parsed through all the D:I .Mesh files and found additional buffer type descriptors.

However, I'm unsure about two new variable contents - I've named them "texture2" and "texture4" for now,
those occur in the following combinations:

texture2: 
tangent, uv, texture2. texture4
normal, uv, texture2
color, tangent, uv, texture2
tangent, uv, texture2

texture4:
tangent, uv, texture4
tangent, uv, texture2. texture4